### PR TITLE
Fix compilation errors with hadoop 3.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val root = Project("spark-redshift", file("."))
 
     // Spark 2.4.x should be compatible with hadoop >= 2.7.x
     // https://spark.apache.org/downloads.html
-    testHadoopVersion := sys.props.get("hadoop.testVersion").getOrElse("2.7.7"),
+    testHadoopVersion := sys.props.get("hadoop.testVersion").getOrElse("3.2.0"),
 
     // DON't UPGRADE AWS-SDK-JAVA if not compatible with hadoop version
     // https://stackoverflow.com/a/49510602/2544874

--- a/src/test/java/io/github/spark_redshift_community/spark/redshift/InMemoryS3AFileSystem.java
+++ b/src/test/java/io/github/spark_redshift_community/spark/redshift/InMemoryS3AFileSystem.java
@@ -203,13 +203,13 @@ public class InMemoryS3AFileSystem extends FileSystem {
             dataMap.get(toS3Key(f)).toByteArray().length, true, 1,
             this.getDefaultBlockSize(), System.currentTimeMillis(), f
         );
-        S3AFileStatus status = S3AFileStatus.fromFileStatus(
-            fileStatus, Tristate.fromBool(
-                dataMap.tailMap(toS3Key(f)).size() == 1 && dataMap.containsKey(toS3Key(f))
-            )
-        );
 
         if (isDir(f)) {
+            S3AFileStatus status = S3AFileStatus.fromFileStatus(
+                fileStatus, Tristate.fromBool(
+                    dataMap.tailMap(toS3Key(f)).size() == 1 && dataMap.containsKey(toS3Key(f))
+                )
+            );
             return status;
         }
         else {

--- a/src/test/java/io/github/spark_redshift_community/spark/redshift/InMemoryS3AFileSystem.java
+++ b/src/test/java/io/github/spark_redshift_community/spark/redshift/InMemoryS3AFileSystem.java
@@ -23,7 +23,9 @@ import java.net.URI;
 import java.util.*;
 
 import org.apache.hadoop.fs.*;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.fs.s3a.Tristate;
 import org.apache.hadoop.fs.s3a.S3AFileStatus;
 
 import org.apache.hadoop.conf.Configuration;
@@ -108,6 +110,8 @@ public class InMemoryS3AFileSystem extends FileSystem {
 
     @Override
     public FSDataOutputStream create(Path f) throws IOException {
+        // TODO: This could possibly be wrong
+        FileSystem.Statistics statistics = null;
 
         if (exists(f)) {
             throw new FileAlreadyExistsException();
@@ -118,7 +122,7 @@ public class InMemoryS3AFileSystem extends FileSystem {
 
         dataMap.put(key, inMemoryS3File);
 
-        return new FSDataOutputStream(inMemoryS3File);
+        return new FSDataOutputStream(inMemoryS3File, statistics);
 
     }
 
@@ -192,23 +196,29 @@ public class InMemoryS3AFileSystem extends FileSystem {
 
 
     @Override
-    public  S3AFileStatus getFileStatus(Path f) throws IOException {
+    public S3AFileStatus getFileStatus(Path f) throws IOException {
 
         if (!exists(f)) throw new FileNotFoundException();
+        FileStatus fileStatus = new FileStatus(
+            dataMap.get(toS3Key(f)).toByteArray().length, true, 1,
+            this.getDefaultBlockSize(), System.currentTimeMillis(), f
+        );
+        S3AFileStatus status = S3AFileStatus.fromFileStatus(
+            fileStatus, Tristate.fromBool(
+                dataMap.tailMap(toS3Key(f)).size() == 1 && dataMap.containsKey(toS3Key(f))
+            )
+        );
 
         if (isDir(f)) {
-            return new S3AFileStatus(
-                true,
-                dataMap.tailMap(toS3Key(f)).size() == 1 && dataMap.containsKey(toS3Key(f)),
-                f
-            );
+            return status;
         }
         else {
             return new S3AFileStatus(
                 dataMap.get(toS3Key(f)).toByteArray().length,
                 System.currentTimeMillis(),
                 f,
-                this.getDefaultBlockSize()
+                this.getDefaultBlockSize(),
+                "owner"
             );
         }
     }

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/InMemoryS3AFileSystemSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/InMemoryS3AFileSystemSuite.scala
@@ -3,6 +3,7 @@ package io.github.spark_redshift_community.spark.redshift
 import java.io.FileNotFoundException
 
 import org.apache.hadoop.fs.{FileAlreadyExistsException, FileStatus, Path}
+import org.apache.hadoop.fs.s3a.Tristate
 import org.scalatest.{FunSuite, Matchers}
 
 class InMemoryS3AFileSystemSuite extends FunSuite with Matchers  {
@@ -64,7 +65,7 @@ class InMemoryS3AFileSystemSuite extends FunSuite with Matchers  {
       "s3a://test-bucket/temp-dir/ba7e0bf3-25a0-4435-b7a5-fdb6b3d2d328")
     val dirPathFileStatus = inMemoryS3AFileSystem.getFileStatus(dirPath)
     assert(dirPathFileStatus.isDirectory === true)
-    assert(dirPathFileStatus.isEmptyDirectory === false)
+    assert(dirPathFileStatus.isEmptyDirectory === Tristate.FALSE)
 
   }
 

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/RedshiftSourceSuite.scala
@@ -23,7 +23,7 @@ import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.{BucketLifecycleConfiguration, S3Object, S3ObjectInputStream}
 import com.amazonaws.services.s3.model.BucketLifecycleConfiguration.Rule
 import io.github.spark_redshift_community.spark.redshift.Parameters.MergedParameters
-import org.apache.http.client.methods.HttpRequestBase
+import com.amazonaws.thirdparty.apache.http.client.methods.HttpRequestBase
 import org.mockito.Matchers._
 import org.mockito.Mockito
 import org.mockito.Mockito.when

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/RedshiftSourceSuite.scala
@@ -28,6 +28,7 @@ import org.mockito.Matchers._
 import org.mockito.Mockito
 import org.mockito.Mockito.when
 import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.fs.UnsupportedFileSystemException
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers}
@@ -615,23 +616,23 @@ class RedshiftSourceSuite
 
   test("Saves throw error message if S3 Block FileSystem would be used") {
     val params = defaultParams + ("tempdir" -> defaultParams("tempdir").replace("s3a", "s3"))
-    val e = intercept[IllegalArgumentException] {
+    val e = intercept[UnsupportedFileSystemException] {
       expectedDataDF.write
         .format("io.github.spark_redshift_community.spark.redshift")
         .mode("append")
         .options(params)
         .save()
     }
-    assert(e.getMessage.contains("Block FileSystem"))
+    assert(e.getMessage.contains("No FileSystem for scheme"))
   }
 
   test("Loads throw error message if S3 Block FileSystem would be used") {
     val params = defaultParams + ("tempdir" -> defaultParams("tempdir").replace("s3a", "s3"))
-    val e = intercept[IllegalArgumentException] {
+    val e = intercept[UnsupportedFileSystemException] {
       testSqlContext.read.format("io.github.spark_redshift_community.spark.redshift")
         .options(params)
         .load()
     }
-    assert(e.getMessage.contains("Block FileSystem"))
+    assert(e.getMessage.contains("No FileSystem for scheme"))
   }
 }


### PR DESCRIPTION
Changes in integration tests to support to fix compilation errors due to hadoop 3.2 api changes. 
Note: The integration tests are still failing at runtime.

Ticket: COREML-1946
Commit 3: Fixed 4 unit tests